### PR TITLE
Transactional update attributes

### DIFF
--- a/lib/tripod/persistence.rb
+++ b/lib/tripod/persistence.rb
@@ -148,9 +148,9 @@ module Tripod::Persistence
     end
   end
 
-  def update_attribute(name, value)
+  def update_attribute(name, value, opts={})
     write_attribute(name, value)
-    save
+    save(opts)
   end
 
   def update_attributes(attributes, opts={})


### PR DESCRIPTION
Let .update_attributes and .update_attribute accept options, allowing transactions to be used.
