### PR TITLE
Make caching endpoint aware

### DIFF
--- a/lib/tripod/sparql_client.rb
+++ b/lib/tripod/sparql_client.rb
@@ -36,7 +36,7 @@ module Tripod::SparqlClient
         Tripod.logger.debug "TRIPOD: caching is on!"
         # SHA-2 the key to keep the it within the small limit for many cache stores (e.g. Memcached is 250bytes)
         # Note: SHA2's are pretty certain to be unique http://en.wikipedia.org/wiki/SHA-2.
-        cache_key = 'SPARQL-QUERY-' + Digest::SHA2.hexdigest([extra_params, accept_header, sparql].join("-"))
+        cache_key = 'SPARQL-QUERY-' + Digest::SHA2.hexdigest([extra_params, accept_header, sparql, Tripod.query_endpoint].join("-"))
         Tripod.cache_store.fetch(cache_key, &stream_data)
       else
         Tripod.logger.debug "TRIPOD caching is off!"

--- a/lib/tripod/version.rb
+++ b/lib/tripod/version.rb
@@ -1,3 +1,3 @@
 module Tripod
-  VERSION = "0.11.0"
+  VERSION = "0.11.1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,12 +31,12 @@ end
 
 # configure any settings for testing...
 Tripod.configure do |config|
-  config.update_endpoint = 'http://127.0.0.1:3030/tripod-test/update'
-  config.query_endpoint = 'http://127.0.0.1:3030/tripod-test/sparql'
-  #config.data_endpoint = 'http://127.0.0.1:3030/tripod-test/data'
+  # config.update_endpoint = 'http://127.0.0.1:3030/tripod-test/update'
+  # config.query_endpoint = 'http://127.0.0.1:3030/tripod-test/sparql'
+  # config.data_endpoint = 'http://127.0.0.1:3030/tripod-test/data'
 
-  # config.update_endpoint = 'http://127.0.0.1:3002/sparql/raw/update'
-  # config.query_endpoint = 'http://127.0.0.1:3002/sparql/raw'
+  config.update_endpoint = 'http://127.0.0.1:3002/sparql/raw/update'
+  config.query_endpoint = 'http://127.0.0.1:3002/sparql/raw'
   #config.data_endpoint = 'http://127.0.0.1:3030/tripod-test/data'
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,12 +31,12 @@ end
 
 # configure any settings for testing...
 Tripod.configure do |config|
-  # config.update_endpoint = 'http://127.0.0.1:3030/tripod-test/update'
-  # config.query_endpoint = 'http://127.0.0.1:3030/tripod-test/sparql'
-  # config.data_endpoint = 'http://127.0.0.1:3030/tripod-test/data'
+  config.update_endpoint = 'http://127.0.0.1:3030/tripod-test/update'
+  config.query_endpoint = 'http://127.0.0.1:3030/tripod-test/sparql'
+  #config.data_endpoint = 'http://127.0.0.1:3030/tripod-test/data'
 
-  config.update_endpoint = 'http://127.0.0.1:3002/sparql/raw/update'
-  config.query_endpoint = 'http://127.0.0.1:3002/sparql/raw'
+  # config.update_endpoint = 'http://127.0.0.1:3002/sparql/raw/update'
+  # config.query_endpoint = 'http://127.0.0.1:3002/sparql/raw'
   #config.data_endpoint = 'http://127.0.0.1:3030/tripod-test/data'
 end
 


### PR DESCRIPTION
Make the cache key also include the tripod endpoint that was called, to avoid recalling the wrong data for multi-tenanted apps that have different endpoints per user.