### PR TITLE
Multiple graph clauses

### DIFF
--- a/lib/tripod/criteria.rb
+++ b/lib/tripod/criteria.rb
@@ -87,11 +87,15 @@ module Tripod
     end
 
     # Restrict this query to the graph uri passed in
+    # You may also pass a block to an unbound graph, ?g
+    # then chain a where clause to the criteria returned to bind ?g
     #
     # @example .graph(RDF::URI.new('http://graphoid')
     # @example .graph('http://graphoid')
+    # @example .graph(nil) { "?s ?p ?o" }.where("?uri ?p ?g")
     #
     # @param [ String, RDF::URI ] The graph uri
+    # @param [ Block ] A string to be executed within an unbound graph, ?g
     #
     # @return [ Tripod::Criteria ] A criteria object
     def graph(graph_uri, &block)

--- a/lib/tripod/criteria.rb
+++ b/lib/tripod/criteria.rb
@@ -91,19 +91,14 @@ module Tripod
     # @example .graph(RDF::URI.new('http://graphoid')
     # @example .graph('http://graphoid')
     #
-    # @param [ Stirng, RDF::URI ] The graph uri
+    # @param [ String, RDF::URI ] The graph uri
     #
     # @return [ Tripod::Criteria ] A criteria object
     def graph(graph_uri, &block)
 
       if block_given?
         self.graph_lambdas ||= []
-
-        self.graph_lambdas << -> {
-          block.each do |criteria|
-            criteria.as_query(return_graph: false)
-          end.join(" . ")
-        }
+        self.graph_lambdas << block
         self
       else
         self.graph_uri = graph_uri.to_s

--- a/spec/tripod/criteria_execution_spec.rb
+++ b/spec/tripod/criteria_execution_spec.rb
@@ -36,9 +36,9 @@ describe Tripod::Criteria do
 
       it "should be possible to bind to the ?g paramter on the criteria after supplying a block" do
         resource_criteria.graph(nil) do
-          "?uri ?p ?o"
+          "?s ?p ?o"
         end.where("?uri ?p ?g")
-        resource_criteria.as_query.should == "SELECT DISTINCT ?uri WHERE { GRAPH ?g { ?uri ?p ?o } ?uri ?p ?g }"
+        resource_criteria.as_query.should == "SELECT DISTINCT ?uri WHERE { GRAPH ?g { ?s ?p ?o } ?uri ?p ?g }"
       end
     end
 

--- a/spec/tripod/criteria_execution_spec.rb
+++ b/spec/tripod/criteria_execution_spec.rb
@@ -31,7 +31,7 @@ describe Tripod::Criteria do
         resource_criteria.graph(nil) do
           "?uri ?p ?o"
         end
-        resource_criteria.as_query.should == "SELECT DISTINCT ?uri WHERE { GRAPH ?g { ?uri ?p ?o }}"
+        resource_criteria.as_query.should == "SELECT DISTINCT ?uri WHERE { GRAPH ?g { ?uri ?p ?o } ?uri ?p ?o }"
       end
 
       it "should be possible to bind to the ?g paramter on the criteria after supplying a block" do

--- a/spec/tripod/criteria_execution_spec.rb
+++ b/spec/tripod/criteria_execution_spec.rb
@@ -26,6 +26,22 @@ describe Tripod::Criteria do
 
   describe "#as_query" do
 
+    context "when graph_lambdas exist" do
+      it "should return the contents of the block inside a graph statement with unbound ?g parameter" do
+        resource_criteria.graph(nil) do
+          "?uri ?p ?o"
+        end
+        resource_criteria.as_query.should == "SELECT DISTINCT ?uri WHERE { GRAPH ?g { ?uri ?p ?o }}"
+      end
+
+      it "should be possible to bind to the ?g paramter on the criteria after supplying a block" do
+        resource_criteria.graph(nil) do
+          "?uri ?p ?o"
+        end.where("?uri ?p ?g")
+        resource_criteria.as_query.should == "SELECT DISTINCT ?uri WHERE { GRAPH ?g { ?uri ?p ?o } ?uri ?p ?g }"
+      end
+    end
+
     context "for a class with an rdf_type and graph" do
       it "should return a SELECT query based with an rdf type restriction" do
         person_criteria.as_query.should == "SELECT DISTINCT ?uri (<http://example.com/graph> as ?graph) WHERE { GRAPH <http://example.com/graph> { ?uri a <http://example.com/person> } }"

--- a/spec/tripod/criteria_spec.rb
+++ b/spec/tripod/criteria_spec.rb
@@ -141,7 +141,11 @@ describe Tripod::Criteria do
     context "with a block" do
 
       it "will convert each criteria in the block to a query" do
-        pending
+        resource_criteria.graph(nil) do
+          "?uri ?p ?o"
+        end.where("?uri ?p ?g")
+
+        resource_criteria.graph_lambdas.should_not be_empty
       end
 
     end

--- a/spec/tripod/criteria_spec.rb
+++ b/spec/tripod/criteria_spec.rb
@@ -16,6 +16,10 @@ describe Tripod::Criteria do
       person_criteria.extra_clauses.should == []
     end
 
+    it "should initialize the graph lambdas to a blank array" do
+      person_criteria.graph_lambdas.should == []
+    end
+
     context "with rdf_type set on the class" do
       it "should initialize the where clauses to include a type restriction" do
         person_criteria.where_clauses.should == ["?uri a <http://example.com/person>"]
@@ -132,6 +136,14 @@ describe Tripod::Criteria do
     it "sets the graph_uri for this criteria, as a string" do
       resource_criteria.graph(RDF::URI("http://example.com/foobar"))
       resource_criteria.graph_uri.should == "http://example.com/foobar"
+    end
+
+    context "with a block" do
+
+      it "will convert each criteria in the block to a query" do
+        pending
+      end
+
     end
   end
 


### PR DESCRIPTION
- Ability to add unbound graphs and sparql strings to be executed within these
- This means you can return the containing graphs for resources that are connected by triples as part of a Tripod criteria object
- Tests added for this behaviour