### PR TITLE
Allow additional request headers to be specified in requests.

### DIFF
--- a/lib/tripod.rb
+++ b/lib/tripod.rb
@@ -52,6 +52,9 @@ module Tripod
   mattr_accessor :extra_endpoint_params
   @@extra_endpoint_params = {}
 
+  mattr_accessor :extra_endpoint_headers
+  @@extra_endpoint_headers = {}
+
   mattr_accessor :timeout_seconds
   @@timeout_seconds = 30
 

--- a/lib/tripod/sparql_client.rb
+++ b/lib/tripod/sparql_client.rb
@@ -14,13 +14,14 @@ module Tripod::SparqlClient
     # @param [ String ] accept_header The accept header to send with the request
     # @param [ Hash ] any extra params to send with the request
     # @return [ RestClient::Response ]
-    def self.query(sparql, accept_header, extra_params={}, response_limit_bytes = :default)
+    def self.query(sparql, accept_header, extra_params={}, response_limit_bytes = :default, extra_headers = {})
 
       non_sparql_params = (Tripod.extra_endpoint_params).merge(extra_params)
       params_hash = {:query => sparql}.merge(non_sparql_params)
       params = self.to_query(params_hash)
       request_url = Tripod.query_endpoint
-      streaming_opts = {:accept => accept_header, :timeout_seconds => Tripod.timeout_seconds}
+      extra_headers.merge!(Tripod.extra_endpoint_headers)
+      streaming_opts = {:accept => accept_header, :timeout_seconds => Tripod.timeout_seconds, :extra_headers => extra_headers}
       streaming_opts.merge!(_response_limit_options(response_limit_bytes)) if Tripod.response_limit_bytes
 
       # Hash.to_query from active support core extensions

--- a/lib/tripod/streaming.rb
+++ b/lib/tripod/streaming.rb
@@ -11,9 +11,16 @@ module Tripod
     #  :response_limit_bytes = nil
     def self.get_data(request_url, payload, opts={})
 
-      accept = opts[:accept] || "*/*"
+      accept = opts[:accept]
       timeout_in_seconds = opts[:timeout_seconds] || 10
       limit_in_bytes = opts[:response_limit_bytes]
+
+      # set request headers
+      headers = opts[:extra_headers] || {}
+
+      # if explicit accept option is given, set it in the headers (and overwrite any existing value in the extra_headers map)
+      # if none is given accept */*
+      headers['Accept'] = accept || headers['Accept'] || '*/*'
 
       uri = URI(request_url)
 
@@ -27,7 +34,7 @@ module Tripod
       response = StringIO.new
 
       begin
-        http.request_post(uri.request_uri, payload, 'Accept' => accept) do |res|
+        http.request_post(uri.request_uri, payload, headers) do |res|
 
           response_duration = Time.now - request_start_time if Tripod.logger.debug?
 


### PR DESCRIPTION
Add an optional extra_headers parameter to SparqlClient::Query.query
for a map of extra headers to add to the outgoing HTTP request.

Add Tripod.extra_endpoint_headers attribute which allows a collection
of headers to be added to all outgoing requests.