### PR TITLE
Send any additional headers with update requests.

### DIFF
--- a/lib/tripod/sparql_client.rb
+++ b/lib/tripod/sparql_client.rb
@@ -17,9 +17,9 @@ module Tripod::SparqlClient
     def self.query(sparql, accept_header, extra_params={}, response_limit_bytes = :default, extra_headers = {})
 
       non_sparql_params = (Tripod.extra_endpoint_params).merge(extra_params)
-      params_hash = {:query => sparql}.merge(non_sparql_params)
+      params_hash = {:query => sparql}
       params = self.to_query(params_hash)
-      request_url = Tripod.query_endpoint
+      request_url = URI(Tripod.query_endpoint).tap {|u| u.query = non_sparql_params.to_query}.to_s
       extra_headers.merge!(Tripod.extra_endpoint_headers)
       streaming_opts = {:accept => accept_header, :timeout_seconds => Tripod.timeout_seconds, :extra_headers => extra_headers}
       streaming_opts.merge!(_response_limit_options(response_limit_bytes)) if Tripod.response_limit_bytes

--- a/lib/tripod/sparql_client.rb
+++ b/lib/tripod/sparql_client.rb
@@ -99,14 +99,13 @@ module Tripod::SparqlClient
     # @return [ true ]
     def self.update(sparql)
       begin
+        headers = Tripod.extra_endpoint_headers.merge({:content_type => 'application/sparql-update'})
         RestClient::Request.execute(
           :method => :post,
           :url => Tripod.update_endpoint,
           :timeout => Tripod.timeout_seconds,
           :payload => { update: sparql }.merge(Tripod.extra_endpoint_params),
-          :headers => {
-            :content_type => 'application/sparql-update'
-          }
+          :headers => headers
         )
         true
       rescue RestClient::BadRequest => e

--- a/tripod.gemspec
+++ b/tripod.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "activemodel", ">= 3.2", "< 4.3.0"
   gem.add_dependency "activesupport", ">= 3.2", "< 4.3.0"
   gem.add_dependency "equivalent-xml"
-  gem.add_dependency "rdf", "~> 1.1"
+  gem.add_dependency "rdf", ">= 1.1"
   gem.add_dependency "rdf-rdfxml"
   gem.add_dependency "rdf-turtle"
   gem.add_dependency "rdf-json"


### PR DESCRIPTION
If any additional request headers are configured, add them to outgoing
SPARQL update requests.
