### PR TITLE
Use application/x-www-form-urlencoded content type for SPARQL updates.

### DIFF
--- a/lib/tripod/sparql_client.rb
+++ b/lib/tripod/sparql_client.rb
@@ -99,7 +99,7 @@ module Tripod::SparqlClient
     # @return [ true ]
     def self.update(sparql)
       begin
-        headers = Tripod.extra_endpoint_headers.merge({:content_type => 'application/sparql-update'})
+        headers = Tripod.extra_endpoint_headers
         RestClient::Request.execute(
           :method => :post,
           :url => Tripod.update_endpoint,


### PR DESCRIPTION
(https://www.w3.org/TR/sparql11-protocol/#query-via-post-urlencoded),
update queries specified with named parameters should have a content
type of application/x-www-form-urlencoded. RestClient sets this content
type based on the request payload and outputs a warning if the
content type is being overriden. This is the case for update queries
created in SparqlClient::Update.update where the content_type header
of application/sparql-update is being replaced.

Remove explicit application/sparql-update content type to remove the
warning logged by RestClient.