### PR TITLE
Raise a Timeout error on SPARQL query 503 response.

### DIFF
--- a/lib/tripod/streaming.rb
+++ b/lib/tripod/streaming.rb
@@ -39,7 +39,12 @@ module Tripod
           response_duration = Time.now - request_start_time if Tripod.logger.debug?
 
           Tripod.logger.debug "TRIPOD: received response code: #{res.code} in: #{response_duration} secs"
-          raise Tripod::Errors::BadSparqlRequest.new(res.body) if res.code.to_s != "200"
+
+          if res.code.to_i == 503
+            raise Tripod::Errors::Timeout.new
+          elsif res.code.to_s != "200"
+            raise Tripod::Errors::BadSparqlRequest.new(res.body)
+          end
 
           stream_start_time = Time.now if Tripod.logger.debug?
 

--- a/spec/tripod/sparql_client_spec.rb
+++ b/spec/tripod/sparql_client_spec.rb
@@ -21,5 +21,40 @@ module Tripod::SparqlClient
         end
       end
     end
+
+    describe '.query' do
+      let(:port) { 8080 }
+      before do
+        @query_endpoint = Tripod.query_endpoint
+        Tripod.query_endpoint = "http://localhost:#{port}/sparql/query"
+        @server_thread = Thread.new do
+          Timeout::timeout(5) do
+            listener = TCPServer.new port
+            client = listener.accept
+
+            # read request
+            loop do
+              line = client.gets
+              break if line =~ /^\s*$/
+            end
+
+            # write response
+            client.puts "HTTP/1.1 503 Timeout"
+            client.puts "Content-Length: 0"
+            client.puts
+            client.puts
+          end
+        end
+      end
+
+      after do
+        Tripod.query_endpoint = @query_endpoint
+        @server_thread.join
+      end
+
+      it 'should raise timeout error' do
+        expect { Tripod::SparqlClient::Query.query('SELECT * WHERE { ?s ?p ?o }', 'application/n-triples') }.to raise_error(Tripod::Errors::Timeout)
+      end
+    end
   end
 end


### PR DESCRIPTION
If the response from a SPARQL query request is a 503 'Service
Unavailable' response, treat it as a timeout and raise a
Tripod::Errors::Timeout error.