### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/tripod.gemspec
+++ b/tripod.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |gem|
   gem.version       = Tripod::VERSION
 
   gem.required_rubygems_version = ">= 1.3.6"
-  gem.rubyforge_project         = "tripod"
 
   gem.add_dependency "rest-client"
   gem.add_dependency "activemodel", ">= 3.2", "< 4.3.0"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436